### PR TITLE
就...把客户端的强迫症治疗部分都改了吧

### DIFF
--- a/ChatBridgeReforged_client_mc.py
+++ b/ChatBridgeReforged_client_mc.py
@@ -405,6 +405,7 @@ def on_info(server : ServerInterface, info : Info):
         clen = len(args)
 
         if args[0] == prefix:
+            info.cancel_send_to_server()
             # !!CBR [help]
             if clen == 0 or bool(clen == 1 and args[1] == 'help'):
                 show_help(info)


### PR DESCRIPTION
对客户端：
换掉了logger（包括独立运行模式也换了）
换掉了config加载（嘛，换成了yaml，因为你没给原来的json配置文件我就直接拿旧cb的贴进去当默认了，要能用的话记得把你的json贴进去，换掉那个default_config那里就行了）
改掉了解info, 现在没有错误指令漏网之鱼了（当然不改也不是不能用就是了，主要是就是为了那个cancel_send_to_server()才看那里的，然后看到一坨存在漏网之鱼的逻辑，难受）

就酱，不包能用，爱并不并
